### PR TITLE
Add color for interrupted cell

### DIFF
--- a/lc_multi_outputs/nbextension/main.css
+++ b/lc_multi_outputs/nbextension/main.css
@@ -90,6 +90,20 @@
     height: 100%;
 }
 
+.cell-status-interuption .input_prompt {
+    background-color: #ffc125;
+    height: 100%;
+}
+
+.cell-status-interuption .multi-output-tabs .out_prompt_bg {
+    background-color: #ffc125;
+}
+
+.cell-status-interuption .output_wrapper .out_prompt_bg {
+    background-color: #ffc125;
+    height: 100%;
+}
+
 .multi-output-container.ui-tabs {
     border: none;
     padding: 0px;

--- a/lc_multi_outputs/nbextension/main.js
+++ b/lc_multi_outputs/nbextension/main.js
@@ -38,14 +38,17 @@ define([
         cell.element.removeClass('cell-status-success');
         cell.element.removeClass('cell-status-error');
         cell.element.removeClass('cell-status-inqueue');
+		cell.element.removeClass('cell-status-interuption');
 
         if(first == true) {
             cell.element.addClass('cell-status-inqueue');
         } else {
-            if (msg.content.status != "ok" && msg.content.status != "aborted") {
+            if (msg.content.status != "ok" && msg.content.status != "abort") {
                 cell.element.addClass('cell-status-error');
-            } else if (msg.content.status != "aborted") {
+            } else if (msg.content.status != "abort") {
                 cell.element.addClass('cell-status-success');
+            } else if (msg.content.status == "abort"){
+                cell.element.addClass('cell-status-interuption');
             }
         }
     }


### PR DESCRIPTION
Add orange color for interrupted cells to distinguish them from cells failed to execute .

Before : 

![image](https://user-images.githubusercontent.com/46919666/51734644-1e8ede80-20c0-11e9-9e75-c87a4fe81a39.png)

Now : 

![image](https://user-images.githubusercontent.com/46919666/51734675-336b7200-20c0-11e9-9999-1bb5cfbdd56b.png)

And I will make Pull Request for LC_run_through to update related color in heading cell.
