### PR TITLE
出力結果を保存する機能を任意のセルに適用できるように修正

### DIFF
--- a/lc_multi_outputs/nbextension/main.js
+++ b/lc_multi_outputs/nbextension/main.js
@@ -194,21 +194,24 @@ define([
 
     function create_pin_button(cell, output_area)
     {
-        var container = $('<div/>')
-                    .addClass('multi-outputs-ui')
-                    .appendTo(output_area.wrapper.find('.out_prompt_overlay'));
+        var disable_pins = cell.metadata.disable_pins
+        if (disable_pins === undefined || disable_pins === false ) {
+            var container = $('<div/>')
+                        .addClass('multi-outputs-ui')
+                        .appendTo(output_area.wrapper.find('.out_prompt_overlay'));
 
-        var btn = $('<div/>')
-                    .addClass('buttons')
-                    .append('<button class="btn btn-default"/>')
-                    .appendTo(container);
+            var btn = $('<div/>')
+                        .addClass('buttons')
+                        .append('<button class="btn btn-default"/>')
+                        .appendTo(container);
 
-        var clickable = btn.find('button');
-        $('<i class="fa fa-fw fa-thumb-tack"/>').appendTo(clickable);
-        clickable.on('click', function (event) {
-            pin_output(cell);
-            return false;
-        });
+            var clickable = btn.find('button');
+            $('<i class="fa fa-fw fa-thumb-tack"/>').appendTo(clickable);
+            clickable.on('click', function (event) {
+                pin_output(cell);
+                return false;
+            });
+        }
     }
 
     function create_diff_button(cell, pinned_output) {


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/NII-cloud-operation/Jupyter-multi_outputs/issues/50

## やったこと

* 出力結果を保存する機能を任意のコードセルに適用できるように修正

## やらないこと

* なし

## できるようになること（ユーザ目線）

* Notebook作成者にてピン止め機能を適用したいセルを選択することができる。

## できなくなること（ユーザ目線）

* 無し
  (メタデータを付与していない場合(既存ノートブックなど)は、ピン止め機能を適用するようにしています。)

## 動作確認

* 解析基盤が提供しているBinderHub上での動作確認。
  (メタデータにより出力結果保存処理のバリエーションなど) 

## その他
* panelというアプリケーションに本アプリケーションを適用させるよりも、
   Notebookを作成する側で適用したいセルを選択できた方が汎用的であると考え、このような修正になっております。
  修正方針が異なるなどがありましたらご指摘いただければと思います。
   