### PR TITLE
Fix error background color leaking to skipped cells during multi-cell execution

### DIFF
--- a/src/useColorPrompt.ts
+++ b/src/useColorPrompt.ts
@@ -1,4 +1,4 @@
-import { Cell, ICellModel } from '@jupyterlab/cells';
+import { Cell, CodeCell, ICellModel } from '@jupyterlab/cells';
 import { NotebookActions } from '@jupyterlab/notebook';
 
 export function useColorPrompt(): void {
@@ -7,6 +7,17 @@ export function useColorPrompt(): void {
   });
 
   NotebookActions.executed.connect((_, { cell, success }) => {
+    const execCount =
+      cell.model.type === 'code'
+        ? (cell as CodeCell).model.executionCount
+        : null;
+    // Skip cells that were not actually executed:
+    // - Cells skipped after an error during multi-cell execution
+    // - Non-code cells (e.g., Markdown) which always have executionCount === null
+    if (execCount === null) {
+      resetCellStatus(cell);
+      return;
+    }
     setCellResult(cell, success);
   });
 }


### PR DESCRIPTION
## Summary                                                                                                                       
 - Fix a bug where skipped cells after an error were incorrectly shown with the error background color (pink) during multi-cell execution

## Problem
When executing multiple cells at once, if a cell encounters an error, the `NotebookActions.executed` signal is still fired with `success=false` for subsequent cells that were not actually executed.
The previous code passed this signal directly to `setCellResult`, causing the error background color to be applied to cells that were never executed.

## Fix
Check the cell's `executionCount` in the `NotebookActions.executed` callback. Cells skipped after an error have `executionCount === null`, so when it is `null`, call `resetCellStatus` instead of `setCellResult` to clear the background color.